### PR TITLE
Fix Dependency List

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,8 @@
     "web-vitals": "^2.1.4"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-scripts": "5.0.0"
+    "react": ">=17.0.2",
+    "react-dom": ">=17.0.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-volume-indicator",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": false,
   "description": "Volume Indicator for react",
   "main": "dist/index.js",
@@ -20,10 +20,12 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
+    "web-vitals": "^2.1.4"
+  },
+  "peerDependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-scripts": "5.0.0",
-    "web-vitals": "^2.1.4"
+    "react-scripts": "5.0.0"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -52,6 +54,9 @@
   "devDependencies": {
     "@babel/cli": "^7.17.6",
     "@babel/core": "^7.17.5",
-    "@babel/preset-env": "^7.16.11"
+    "@babel/preset-env": "^7.16.11",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-scripts": "5.0.0"
   }
 }


### PR DESCRIPTION
While attempting to use this project with my React 18 application, I ran into a `useHook` error. 
![image](https://user-images.githubusercontent.com/46857621/227425428-bee457dd-4279-4e54-836e-7a4e951bd7dd.png)

When I ran down the error, it turns out it can be caused by mismatched versions of react. 
[Stackoverflow thread here.](https://stackoverflow.com/questions/30451556/what-is-the-correct-way-of-adding-a-dependency-to-react-in-your-package-json-for)

Changing `package.json` and [publishing it to npm](https://www.npmjs.com/package/@bmswens/react-volume-indicator) allowed me to use on my react 18 application with no issue.

I would like to get verify that this didn't break your dev environment, and merge it in so I can switch my decency back to your package.